### PR TITLE
Refactor Scripts

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,36 +1,229 @@
 #!/bin/bash
-# benchmark_preload.sh
+# Benchmark script for preload-ng
+# Compares application startup time with and without preload
 
-echo "=== BENCHMARK WITHOUT PRELOAD ==="
-# Stop preload and remove all traces
-sudo systemctl stop preload-ng
+set -e
 
-# Sync all pending buffers to disk
-sync
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
-# Completely clear page cache, dentries and inodes
-# 1 = pagecache, 2 = dentries/inodes, 3 = both
-echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null
+# Configuration
+SERVICE_NAME="preload-ng"
+DEFAULT_APP="gimp"
+WARMUP_RUNS=1
+BENCHMARK_RUNS=10
+PRELOAD_WAIT=40
 
-# Release swap if available (forces pages in swap to return and be discarded)
-sudo swapoff -a 2>/dev/null && sudo swapon -a 2>/dev/null
+print_header() {
+    echo -e "${BLUE}==========================================${NC}"
+    echo -e "${BLUE}  Preload-NG - Benchmark Script${NC}"
+    echo -e "${BLUE}==========================================${NC}"
+    echo ""
+}
 
-# Wait for system to stabilize
-sleep 5
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
 
-echo "Cache cleared. Starting baseline benchmark..."
-hyperfine --warmup 1 --runs 10 \
-    --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null; sleep 2' \
-    'gimp & xdotool search --sync --onlyvisible --class "gimp" windowkill'
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}→ $1${NC}"
+}
+
+check_root() {
+    if [ "$EUID" -ne 0 ]; then
+        print_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+check_dependencies() {
+    print_info "Checking dependencies..."
+
+    local missing=()
+
+    if ! command -v hyperfine &>/dev/null; then
+        missing+=("hyperfine")
+    fi
+
+    if ! command -v xdotool &>/dev/null; then
+        missing+=("xdotool")
+    fi
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        echo ""
+        echo "Please install them first:"
+        echo "  Debian/Ubuntu: sudo apt install ${missing[*]}"
+        echo "  Fedora: sudo dnf install ${missing[*]}"
+        echo "  Arch: sudo pacman -S ${missing[*]}"
+        exit 1
+    fi
+
+    print_success "All dependencies found"
+}
+
+clear_cache() {
+    print_info "Clearing system caches..."
+
+    # Sync all pending buffers to disk
+    sync
+
+    # Completely clear page cache, dentries and inodes
+    # 1 = pagecache, 2 = dentries/inodes, 3 = both
+    echo 3 | tee /proc/sys/vm/drop_caches >/dev/null
+
+    # Release swap if available (forces pages in swap to return and be discarded)
+    swapoff -a 2>/dev/null && swapon -a 2>/dev/null || true
+
+    print_success "Cache cleared"
+}
+
+run_benchmark() {
+    local app="$1"
+    local window_class="$2"
+
+    echo ""
+    print_info "Running benchmark for: $app"
+    echo ""
+
+    hyperfine --warmup "$WARMUP_RUNS" --runs "$BENCHMARK_RUNS" \
+        --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null; sleep 2' \
+        "$app & xdotool search --sync --onlyvisible --class \"$window_class\" windowkill"
+}
+
+benchmark_without_preload() {
+    echo ""
+    echo -e "${YELLOW}==========================================${NC}"
+    echo -e "${YELLOW}  BENCHMARK WITHOUT PRELOAD${NC}"
+    echo -e "${YELLOW}==========================================${NC}"
+    echo ""
+
+    print_info "Stopping preload service..."
+    systemctl stop "$SERVICE_NAME" 2>/dev/null || print_warning "Service not running"
+
+    clear_cache
+
+    print_info "Waiting for system to stabilize (5s)..."
+    sleep 5
+
+    run_benchmark "$APP" "$APP_CLASS"
+}
+
+benchmark_with_preload() {
+    echo ""
+    echo -e "${GREEN}==========================================${NC}"
+    echo -e "${GREEN}  BENCHMARK WITH PRELOAD${NC}"
+    echo -e "${GREEN}==========================================${NC}"
+    echo ""
+
+    print_info "Starting preload service..."
+    systemctl start "$SERVICE_NAME"
+    print_success "Preload service started"
+
+    echo ""
+    print_info "Waiting for preload to learn patterns (${PRELOAD_WAIT}s = 2 cycles)..."
+    sleep "$PRELOAD_WAIT"
+
+    run_benchmark "$APP" "$APP_CLASS"
+}
+
+show_help() {
+    echo "Preload-NG Benchmark Script"
+    echo ""
+    echo "Usage: sudo $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -a, --app APP       Application to benchmark (default: $DEFAULT_APP)"
+    echo "  -c, --class CLASS   Window class for xdotool (default: same as app)"
+    echo "  -r, --runs N        Number of benchmark runs (default: $BENCHMARK_RUNS)"
+    echo "  -w, --wait N        Seconds to wait for preload (default: $PRELOAD_WAIT)"
+    echo "  -h, --help          Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  sudo $0                           # Benchmark GIMP"
+    echo "  sudo $0 -a firefox -c Navigator   # Benchmark Firefox"
+    echo "  sudo $0 -a libreoffice --calc     # Benchmark LibreOffice Calc"
+    echo ""
+}
+
+# Parse arguments
+APP="$DEFAULT_APP"
+APP_CLASS=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -a | --app)
+        APP="$2"
+        shift 2
+        ;;
+    -c | --class)
+        APP_CLASS="$2"
+        shift 2
+        ;;
+    -r | --runs)
+        BENCHMARK_RUNS="$2"
+        shift 2
+        ;;
+    -w | --wait)
+        PRELOAD_WAIT="$2"
+        shift 2
+        ;;
+    -h | --help)
+        show_help
+        exit 0
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+    esac
+done
+
+# Default class to app name if not specified
+if [ -z "$APP_CLASS" ]; then
+    APP_CLASS="$APP"
+fi
+
+# Main
+print_header
+check_root
+check_dependencies
+
+echo "Configuration:"
+echo "  Application:     $APP"
+echo "  Window class:    $APP_CLASS"
+echo "  Benchmark runs:  $BENCHMARK_RUNS"
+echo "  Preload wait:    ${PRELOAD_WAIT}s"
+echo ""
+
+read -p "Start benchmark? (Y/n): " response
+case "$response" in
+[nN] | [nN][oO])
+    echo "Benchmark cancelled."
+    exit 0
+    ;;
+esac
+
+benchmark_without_preload
+benchmark_with_preload
 
 echo ""
-echo "=== BENCHMARK WITH PRELOAD ==="
-sudo systemctl start preload-ng
-
-# Wait for preload to start and make first predictions
-echo "Waiting for preload to learn patterns (40s = 2 cycles)..."
-sleep 40
-
-hyperfine --warmup 1 --runs 10 \
-    --prepare 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches > /dev/null; sleep 2' \
-    'gimp & xdotool search --sync --onlyvisible --class "gimp" windowkill'
+echo -e "${GREEN}==========================================${NC}"
+echo -e "${GREEN}  Benchmark Complete!${NC}"
+echo -e "${GREEN}==========================================${NC}"
+echo ""
+print_info "Compare the 'Mean' times to see the improvement."
+echo ""

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,73 +1,213 @@
 #!/bin/bash
-# Installation script for preload-ng
-# This script compiles and optionally installs preload
+# Build script for preload-ng
+# Compiles preload from source and optionally installs it
 
 set -e
 
-echo "=========================================="
-echo "  Preload-NG - Installation Script"
-echo "=========================================="
-echo ""
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
-# Check dependencies
-echo "[1/4] Checking dependencies..."
+print_header() {
+    echo -e "${BLUE}==========================================${NC}"
+    echo -e "${BLUE}  Preload-NG - Build Script${NC}"
+    echo -e "${BLUE}==========================================${NC}"
+    echo ""
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}→ $1${NC}"
+}
 
 check_command() {
     if ! command -v "$1" &>/dev/null; then
-        echo "Error: '$1' not found. Please install it first."
+        print_error "'$1' not found. Please install it first."
+        return 1
+    fi
+    return 0
+}
+
+check_dependencies() {
+    print_info "Checking build dependencies..."
+    echo ""
+
+    local missing=()
+
+    check_command automake || missing+=("automake")
+    check_command autoconf || missing+=("autoconf")
+    check_command libtool || missing+=("libtool")
+    check_command make || missing+=("make")
+    check_command gcc || missing+=("gcc")
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        echo ""
+        print_error "Missing dependencies: ${missing[*]}"
+        echo ""
+        echo "Please install them first:"
+        echo "  Debian/Ubuntu: sudo apt install ${missing[*]} libglib2.0-dev"
+        echo "  Fedora: sudo dnf install ${missing[*]} glib2-devel"
+        echo "  Arch: sudo pacman -S ${missing[*]} glib2"
         exit 1
+    fi
+
+    print_success "All build dependencies found"
+}
+
+find_source_dir() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    if [ -d "$script_dir/../preload-src" ]; then
+        echo "$script_dir/../preload-src"
+    elif [ -d "./preload-src" ]; then
+        echo "./preload-src"
+    elif [ -d "../preload-src" ]; then
+        echo "../preload-src"
+    else
+        echo ""
     fi
 }
 
-check_command automake
-check_command autoconf
-check_command libtool
-check_command make
-check_command gcc
+clean_build() {
+    if [ -f Makefile ]; then
+        print_info "Cleaning previous build..."
+        make distclean 2>/dev/null || make clean 2>/dev/null || true
+        print_success "Previous build cleaned"
+    fi
+}
 
-# Move to source directory
-if [ -d "preload-src" ]; then
-    cd preload-src
-elif [ -d "../preload-src" ]; then
-    cd ../preload-src
-else
-    echo "Error: preload-src directory not found."
+build() {
+    print_info "[1/3] Configuring build system..."
+    ./bootstrap
+    ./configure
+    print_success "Build system configured"
+
+    echo ""
+    print_info "[2/3] Compiling..."
+    make -j"$(nproc)"
+    print_success "Compilation complete"
+
+    echo ""
+    print_info "[3/3] Build finished!"
+}
+
+install_preload() {
+    echo ""
+    read -p "Do you want to install preload? (y/N): " response
+
+    case "$response" in
+    [yY] | [yY][eE][sS])
+        echo ""
+        print_info "Installing preload (requires root permissions)..."
+        sudo make install
+        print_success "Preload installed"
+
+        echo ""
+        read -p "Enable and start preload service? (Y/n): " enable_response
+        case "$enable_response" in
+        [nN] | [nN][oO])
+            print_info "Service not enabled"
+            ;;
+        *)
+            sudo systemctl enable --now preload
+            print_success "Service enabled and started"
+            ;;
+        esac
+        ;;
+    *)
+        echo ""
+        print_info "Installation skipped"
+        echo "To install manually, run: sudo make install"
+        ;;
+    esac
+}
+
+show_help() {
+    echo "Preload-NG Build Script"
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --clean       Clean build only (no compilation)"
+    echo "  --no-install  Build without prompting to install"
+    echo "  -h, --help    Show this help message"
+    echo ""
+}
+
+# Parse arguments
+CLEAN_ONLY=false
+NO_INSTALL=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --clean)
+        CLEAN_ONLY=true
+        shift
+        ;;
+    --no-install)
+        NO_INSTALL=true
+        shift
+        ;;
+    -h | --help)
+        show_help
+        exit 0
+        ;;
+    *)
+        print_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+    esac
+done
+
+# Main
+print_header
+check_dependencies
+
+# Find and enter source directory
+SOURCE_DIR=$(find_source_dir)
+
+if [ -z "$SOURCE_DIR" ]; then
+    print_error "preload-src directory not found"
     exit 1
 fi
 
-# Clean previous build if Makefile exists
-if [ -f Makefile ]; then
-    echo "Cleaning previous build..."
-    make distclean
+print_info "Source directory: $SOURCE_DIR"
+cd "$SOURCE_DIR"
+
+if [ "$CLEAN_ONLY" = true ]; then
+    clean_build
+    echo ""
+    print_success "Clean complete!"
+    exit 0
 fi
 
-# Build system generation
-echo "[2/4] Configuring build system..."
-./bootstrap
-./configure
-echo "[3/4] Compiling..."
-make
+clean_build
+echo ""
+build
 
-echo "=========================================="
-echo "  Build completed successfully!"
-echo "=========================================="
+echo ""
+echo -e "${GREEN}==========================================${NC}"
+echo -e "${GREEN}  Build Completed Successfully!${NC}"
+echo -e "${GREEN}==========================================${NC}"
 
-# Ask if user wants to install
-read -p "Do you want to install preload? (y/N): " response
+if [ "$NO_INSTALL" = false ]; then
+    install_preload
+fi
 
-case "$response" in
-[yY] | [yY][eE][sS])
-    echo ""
-    echo "Installing preload (requires root permissions)..."
-    sudo make install
-    sudo systemctl enable --now preload
-    echo ""
-    echo "✓ Preload installed successfully!"
-    echo ""
-    ;;
-*)
-    echo ""
-    echo "Installation cancelled."
-    echo "To install manually, run: sudo make install"
-    ;;
-esac
+echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# Installation script for preload-ng (precompiled binary)
+# This script installs the precompiled binary from bin/
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+INSTALL_BIN="/usr/local/sbin"
+INSTALL_CONF="/etc"
+VAR_LIB="/var/lib/preload"
+SYSTEMD_DIR="/etc/systemd/system"
+OPENRC_DIR="/etc/init.d"
+
+# Find the bin directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BIN_DIR="$PROJECT_DIR/bin"
+
+print_header() {
+    echo -e "${BLUE}==========================================${NC}"
+    echo -e "${BLUE}  Preload-NG - Binary Installation${NC}"
+    echo -e "${BLUE}==========================================${NC}"
+    echo ""
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}→ $1${NC}"
+}
+
+check_root() {
+    if [ "$EUID" -ne 0 ]; then
+        print_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+check_binary() {
+    if [ ! -f "$BIN_DIR/preload" ]; then
+        print_error "Precompiled binary not found at: $BIN_DIR/preload"
+        echo ""
+        echo "Please either:"
+        echo "  1. Run 'bash build.sh' to compile from source"
+        echo "  2. Download the precompiled binary from the releases page"
+        exit 1
+    fi
+
+    if [ ! -f "$BIN_DIR/preload.conf" ]; then
+        print_error "Configuration file not found at: $BIN_DIR/preload.conf"
+        exit 1
+    fi
+}
+
+detect_init_system() {
+    if command -v systemctl &>/dev/null && systemctl --version &>/dev/null; then
+        echo "systemd"
+    elif command -v rc-service &>/dev/null; then
+        echo "openrc"
+    elif [ -f /etc/init.d/functions ]; then
+        echo "sysvinit"
+    else
+        echo "unknown"
+    fi
+}
+
+install_binary() {
+    print_info "Installing binary to $INSTALL_BIN/preload..."
+    mkdir -p "$INSTALL_BIN"
+    cp "$BIN_DIR/preload" "$INSTALL_BIN/preload"
+    chmod 755 "$INSTALL_BIN/preload"
+    print_success "Binary installed"
+}
+
+install_config() {
+    if [ -f "$INSTALL_CONF/preload.conf" ]; then
+        print_warning "Configuration file already exists at $INSTALL_CONF/preload.conf"
+        read -p "Overwrite? (y/N): " response
+        case "$response" in
+        [yY] | [yY][eE][sS])
+            cp "$BIN_DIR/preload.conf" "$INSTALL_CONF/preload.conf"
+            print_success "Configuration file overwritten"
+            ;;
+        *)
+            print_info "Keeping existing configuration"
+            ;;
+        esac
+    else
+        print_info "Installing configuration to $INSTALL_CONF/preload.conf..."
+        cp "$BIN_DIR/preload.conf" "$INSTALL_CONF/preload.conf"
+        print_success "Configuration file installed"
+    fi
+    chmod 644 "$INSTALL_CONF/preload.conf"
+}
+
+create_directories() {
+    print_info "Creating required directories..."
+    mkdir -p "$VAR_LIB"
+    chmod 755 "$VAR_LIB"
+    print_success "Directories created"
+}
+
+install_systemd_service() {
+    print_info "Installing systemd service..."
+
+    cat >"$SYSTEMD_DIR/preload.service" <<'EOF'
+[Unit]
+Description=Preload Daemon - Adaptive Readahead
+Documentation=man:preload(8)
+After=local-fs.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/sbin/preload --foreground
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+
+# Security hardening
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/preload /var/log
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    chmod 644 "$SYSTEMD_DIR/preload.service"
+    systemctl daemon-reload
+    print_success "Systemd service installed"
+}
+
+install_openrc_service() {
+    print_info "Installing OpenRC service..."
+
+    cat >"$OPENRC_DIR/preload" <<'EOF'
+#!/sbin/openrc-run
+
+name="preload"
+description="Preload Daemon - Adaptive Readahead"
+command="/usr/local/sbin/preload"
+command_args="--foreground"
+command_background="yes"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+    need localmount
+    after bootmisc
+}
+EOF
+
+    chmod 755 "$OPENRC_DIR/preload"
+    print_success "OpenRC service installed"
+}
+
+enable_service() {
+    local init_system="$1"
+
+    read -p "Enable and start preload service now? (Y/n): " response
+    case "$response" in
+    [nN] | [nN][oO])
+        print_info "Service not enabled. You can enable it later with:"
+        if [ "$init_system" = "systemd" ]; then
+            echo "  sudo systemctl enable --now preload"
+        elif [ "$init_system" = "openrc" ]; then
+            echo "  sudo rc-update add preload default && sudo rc-service preload start"
+        fi
+        ;;
+    *)
+        if [ "$init_system" = "systemd" ]; then
+            systemctl enable preload
+            systemctl start preload
+            print_success "Service enabled and started"
+        elif [ "$init_system" = "openrc" ]; then
+            rc-update add preload default
+            rc-service preload start
+            print_success "Service enabled and started"
+        fi
+        ;;
+    esac
+}
+
+uninstall() {
+    print_header
+    echo "Uninstalling Preload-NG..."
+    echo ""
+
+    local init_system
+    init_system=$(detect_init_system)
+
+    # Stop and disable service
+    if [ "$init_system" = "systemd" ]; then
+        if systemctl is-active --quiet preload 2>/dev/null; then
+            print_info "Stopping service..."
+            systemctl stop preload
+        fi
+        if systemctl is-enabled --quiet preload 2>/dev/null; then
+            print_info "Disabling service..."
+            systemctl disable preload
+        fi
+        if [ -f "$SYSTEMD_DIR/preload.service" ]; then
+            rm -f "$SYSTEMD_DIR/preload.service"
+            systemctl daemon-reload
+            print_success "Systemd service removed"
+        fi
+    elif [ "$init_system" = "openrc" ]; then
+        if rc-service preload status &>/dev/null; then
+            print_info "Stopping service..."
+            rc-service preload stop
+        fi
+        rc-update del preload default 2>/dev/null || true
+        if [ -f "$OPENRC_DIR/preload" ]; then
+            rm -f "$OPENRC_DIR/preload"
+            print_success "OpenRC service removed"
+        fi
+    fi
+
+    # Remove binary
+    if [ -f "$INSTALL_BIN/preload" ]; then
+        rm -f "$INSTALL_BIN/preload"
+        print_success "Binary removed"
+    fi
+
+    # Ask about config and data
+    read -p "Remove configuration file ($INSTALL_CONF/preload.conf)? (y/N): " response
+    case "$response" in
+    [yY] | [yY][eE][sS])
+        rm -f "$INSTALL_CONF/preload.conf"
+        print_success "Configuration file removed"
+        ;;
+    *)
+        print_info "Configuration file kept"
+        ;;
+    esac
+
+    read -p "Remove state data ($VAR_LIB)? (y/N): " response
+    case "$response" in
+    [yY] | [yY][eE][sS])
+        rm -rf "$VAR_LIB"
+        print_success "State data removed"
+        ;;
+    *)
+        print_info "State data kept"
+        ;;
+    esac
+
+    echo ""
+    print_success "Preload-NG uninstalled successfully!"
+}
+
+install() {
+    print_header
+    check_root
+    check_binary
+
+    local init_system
+    init_system=$(detect_init_system)
+
+    echo "Detected init system: $init_system"
+    echo ""
+
+    if [ "$init_system" = "unknown" ]; then
+        print_warning "Could not detect init system"
+        print_info "Will install binary and config only (no service)"
+        echo ""
+    fi
+
+    # Install components
+    install_binary
+    install_config
+    create_directories
+
+    # Install service based on init system
+    case "$init_system" in
+    systemd)
+        install_systemd_service
+        echo ""
+        enable_service "$init_system"
+        ;;
+    openrc)
+        install_openrc_service
+        echo ""
+        enable_service "$init_system"
+        ;;
+    *)
+        print_warning "No service installed. You'll need to start preload manually:"
+        echo "  sudo /usr/local/sbin/preload --foreground"
+        ;;
+    esac
+
+    echo ""
+    echo -e "${GREEN}==========================================${NC}"
+    echo -e "${GREEN}  Installation Complete!${NC}"
+    echo -e "${GREEN}==========================================${NC}"
+    echo ""
+    echo "Binary location:  $INSTALL_BIN/preload"
+    echo "Config location:  $INSTALL_CONF/preload.conf"
+    echo "State directory:  $VAR_LIB"
+    echo ""
+    echo "To check status:  sudo systemctl status preload"
+    echo "To view logs:     sudo journalctl -u preload -f"
+    echo ""
+}
+
+show_help() {
+    echo "Preload-NG Installation Script"
+    echo ""
+    echo "Usage: $0 [OPTION]"
+    echo ""
+    echo "Options:"
+    echo "  install     Install preload-ng (default)"
+    echo "  uninstall   Remove preload-ng from the system"
+    echo "  help        Show this help message"
+    echo ""
+}
+
+# Main
+case "${1:-install}" in
+install)
+    install
+    ;;
+uninstall)
+    check_root
+    uninstall
+    ;;
+help | --help | -h)
+    show_help
+    ;;
+*)
+    print_error "Unknown option: $1"
+    show_help
+    exit 1
+    ;;
+esac

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,71 +1,182 @@
 #!/bin/bash
-# Script to package preload-ng as tar.gz
-# Asks for version and creates file with appropriate name
+# Packaging script for preload-ng
+# Creates a distributable tar.gz archive
 
 set -e
 
-echo "=========================================="
-echo "  Preload-NG - Packaging Script"
-echo "=========================================="
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo -e "${BLUE}==========================================${NC}"
+    echo -e "${BLUE}  Preload-NG - Packaging Script${NC}"
+    echo -e "${BLUE}==========================================${NC}"
+    echo ""
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}! $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}→ $1${NC}"
+}
+
+find_project_dir() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    echo "$(dirname "$script_dir")"
+}
+
+validate_version() {
+    local version="$1"
+
+    if [[ -z "$version" ]]; then
+        print_error "Version cannot be empty"
+        return 1
+    fi
+
+    # Validate version format (allow numbers and dots)
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+        print_warning "Unusual version format: $version"
+        read -p "Continue anyway? (y/N): " response
+        case "$response" in
+        [yY] | [yY][eE][sS])
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+        esac
+    fi
+
+    return 0
+}
+
+create_package() {
+    local project_dir="$1"
+    local version="$2"
+    local project_name
+    local file_name
+    local parent_dir
+
+    project_name=$(basename "$project_dir")
+    file_name="preload-ng-${version}.tar.gz"
+    parent_dir=$(dirname "$project_dir")
+
+    print_info "Creating package: $file_name"
+    echo ""
+
+    # Go to parent directory
+    cd "$parent_dir"
+
+    # Create tar.gz file excluding unnecessary files
+    tar --exclude='*.o' \
+        --exclude='*.a' \
+        --exclude='*.so' \
+        --exclude='*.la' \
+        --exclude='*.lo' \
+        --exclude='.deps' \
+        --exclude='.libs' \
+        --exclude='autom4te.cache' \
+        --exclude='config.h' \
+        --exclude='config.log' \
+        --exclude='config.status' \
+        --exclude='stamp-h1' \
+        --exclude='libtool' \
+        --exclude='*~' \
+        --exclude='*.bak' \
+        --exclude='*.swp' \
+        --exclude='.git' \
+        --exclude='.gitignore' \
+        --exclude='*.tar.gz' \
+        --exclude='result' \
+        -czvf "$file_name" "$project_name"
+
+    # Move to project directory
+    mv "$file_name" "$project_dir/"
+
+    print_success "Package created"
+    echo ""
+    echo "  File: $project_dir/$file_name"
+    echo "  Size: $(du -h "$project_dir/$file_name" | cut -f1)"
+}
+
+show_help() {
+    echo "Preload-NG Packaging Script"
+    echo ""
+    echo "Usage: $0 [OPTIONS] [VERSION]"
+    echo ""
+    echo "Options:"
+    echo "  -v, --version VERSION  Specify version (e.g., 0.6.6)"
+    echo "  -h, --help             Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                     # Prompt for version"
+    echo "  $0 -v 0.6.6            # Create preload-ng-0.6.6.tar.gz"
+    echo "  $0 0.6.7               # Create preload-ng-0.6.7.tar.gz"
+    echo ""
+}
+
+# Parse arguments
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -v | --version)
+        VERSION="$2"
+        shift 2
+        ;;
+    -h | --help)
+        show_help
+        exit 0
+        ;;
+    -*)
+        print_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+    *)
+        VERSION="$1"
+        shift
+        ;;
+    esac
+done
+
+# Main
+print_header
+
+PROJECT_DIR=$(find_project_dir)
+print_info "Project directory: $PROJECT_DIR"
 echo ""
 
-# Ask for version
-read -p "Enter version (example: 0.6.6): " version
+# Ask for version if not provided
+if [ -z "$VERSION" ]; then
+    read -p "Enter version (e.g., 0.6.6): " VERSION
+fi
 
-# Validate input
-if [[ -z "$version" ]]; then
-    echo "Error: Version cannot be empty."
+# Validate version
+if ! validate_version "$VERSION"; then
     exit 1
 fi
 
-# Validate version format (allow numbers and dots)
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-    echo "Warning: Unusual version format. Continuing..."
-fi
-
-# Define file name
-file_name="preload-ng-${version}.tar.gz"
-current_directory=$(basename "$(pwd)")
-parent_directory=$(dirname "$(pwd)")
+echo ""
+create_package "$PROJECT_DIR" "$VERSION"
 
 echo ""
-echo "Creating file: $file_name"
-echo ""
-
-# Go to parent directory and create tar.gz
-cd "$parent_directory"
-
-# Create tar.gz file excluding unnecessary files
-tar --exclude='*.o' \
-    --exclude='*.a' \
-    --exclude='*.so' \
-    --exclude='*.la' \
-    --exclude='*.lo' \
-    --exclude='.deps' \
-    --exclude='.libs' \
-    --exclude='autom4te.cache' \
-    --exclude='config.h' \
-    --exclude='config.log' \
-    --exclude='config.status' \
-    --exclude='stamp-h1' \
-    --exclude='libtool' \
-    --exclude='*~' \
-    --exclude='*.bak' \
-    --exclude='*.swp' \
-    --exclude='.git' \
-    --exclude='.gitignore' \
-    -czvf "$file_name" "$current_directory"
-
-# Move to original directory
-mv "$file_name" "$current_directory/"
-
-cd "$current_directory"
-
-echo ""
-echo "=========================================="
-echo "  Packaging completed!"
-echo "=========================================="
-echo ""
-echo "File created: $(pwd)/$file_name"
-echo "Size: $(du -h "$file_name" | cut -f1)"
+echo -e "${GREEN}==========================================${NC}"
+echo -e "${GREEN}  Packaging Complete!${NC}"
+echo -e "${GREEN}==========================================${NC}"
 echo ""


### PR DESCRIPTION
## Summary

This PR introduces a new binary installation script and standardizes all utility scripts in the `scripts/` directory with consistent styling, improved user experience, and enhanced functionality.

## Changes

### New Script

#### `scripts/install.sh`

A new installation script for users who want to install preload-ng from precompiled binaries without building from source.

**Features:**

- Automatic init system detection (systemd and OpenRC support)
- Installs binary to `/usr/local/sbin/preload`
- Installs configuration to `/etc/preload.conf`
- Creates required directories (`/var/lib/preload`)
- Includes security hardening in systemd service configuration
- Full uninstallation support with `--uninstall` flag
- Preserves existing configuration with user prompts

**Usage:**

```bash
sudo bash install.sh           # Install
sudo bash install.sh uninstall # Uninstall
```

---

### Script Standardization

All scripts in `scripts/` have been refactored with the following improvements:

#### Common Enhancements

| Feature          | Description                                                                     |
| ---------------- | ------------------------------------------------------------------------------- |
| Colored output   | Consistent use of ANSI colors for success, error, warning, and info messages    |
| Helper functions | Unified `print_success`, `print_error`, `print_warning`, `print_info` functions |
| CLI arguments    | Proper argument parsing with `--help` support                                   |
| Input validation | Enhanced validation for user inputs and dependencies                            |
| Error handling   | Consistent `set -e` and meaningful error messages                               |

---

### Modified Scripts

#### `scripts/build.sh`

Refactored build script with improved structure and options.

**New options:**

- `--clean` - Clean build artifacts only
- `--no-install` - Build without installation prompt
- `-h, --help` - Display usage information

**Usage:**

```bash
bash build.sh             # Build and prompt for installation
bash build.sh --clean     # Clean previous build
bash build.sh --no-install # Build only
```

---

#### `scripts/bench.sh`

Enhanced benchmark script with configurable parameters.

**New options:**

- `-a, --app APP` - Application to benchmark (default: gimp)
- `-c, --class CLASS` - Window class for xdotool
- `-r, --runs N` - Number of benchmark runs (default: 10)
- `-w, --wait N` - Seconds to wait for preload learning (default: 40)
- `-h, --help` - Display usage information

**Usage:**

```bash
sudo bash bench.sh                     # Benchmark GIMP
sudo bash bench.sh -a firefox          # Benchmark Firefox
sudo bash bench.sh -a app -c class -r 20 # Custom configuration
```

---

#### `scripts/package.sh`

Improved packaging script with argument support.

**New options:**

- `-v, --version VERSION` - Specify version directly
- `-h, --help` - Display usage information

**Usage:**

```bash
bash package.sh           # Interactive version prompt
bash package.sh -v 0.6.6  # Specify version via flag
bash package.sh 0.6.7     # Specify version as argument
```
